### PR TITLE
django-libsass for compilation of sass files

### DIFF
--- a/wbc/core/static/style.scss
+++ b/wbc/core/static/style.scss
@@ -1,14 +1,14 @@
 @font-face {
     font-family: titillium;
-    src: url('font/TitilliumText25L.otf');
+    src: url('/static/font/TitilliumText25L.otf');
 }
 @font-face {
     font-family: dejavu;
-    src: url('font/DejaVuSansCondensed.ttf');
+    src: url('/static/font/DejaVuSansCondensed.ttf');
 }
 @font-face {
     font-family: dejavu;
-    src: url('font/DejaVuSansCondensed-Bold.ttf');
+    src: url('/static/font/DejaVuSansCondensed-Bold.ttf');
     font-weight: bold;
 }
 html, body {
@@ -518,13 +518,14 @@ a:hover,
     -webkit-border-radius: 3px; 
     -moz-border-radius: 3px;
     border-radius: 3px;
-    /*font-size:12px;
-    font-family:arial, helvetica, sans-serif;*/
-    padding: 10px 10px 10px 10px; 
-    /*text-decoration:none; 
-    display:inline-block;
-    text-shadow: -1px -1px 0 rgba(0,0,0,0.3);
-    font-weight:bold; color*/: #FFFFFF;
+    /* font-size:12px; */
+    /* font-family:arial, helvetica, sans-serif; */
+    padding: 10px 10px 10px 10px;
+    /* text-decoration:none; */
+    /* display:inline-block; */
+    /* text-shadow: -1px -1px 0 rgba(0,0,0,0.3); */
+    /* font-weight: bold;
+    /* color: #FFFFFF; */
     background-color: #FCF0E5; background-image: -webkit-gradient(linear, left top, left bottom, from(#FCF0E5), to(#E8974D));
     background-image: -webkit-linear-gradient(top, #FCF0E5, #E8974D);
     background-image: -moz-linear-gradient(top, #FCF0E5, #E8974D);

--- a/wbc/core/templates/core/layout.html
+++ b/wbc/core/templates/core/layout.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<!DOCTYPE html>
+{% load staticfiles compress %}<!DOCTYPE html>
 <html>
 <head>
     <title>{{site_title}}</title>
@@ -14,7 +14,10 @@
     <link rel="stylesheet" href="{% static 'lib/bootstrap/css/bootstrap.min.css' %}" />
     <link rel="stylesheet" href="{% static 'lib/font-awesome/css/font-awesome.min.css' %}" />
     {% block css %}{% endblock %}
-    <link rel="stylesheet" href="{% static 'style.css' %}" />
+
+    {% compress css %}
+    <link rel="stylesheet" type="text/x-scss" href="{% static "style.scss" %}" />
+    {% endcompress %}
 
     <script type="text/javascript" src="{% static 'lib/jquery.min.js' %}" ></script>
     <script type="text/javascript" src="{% static 'lib/angular/angular.min.js' %}" ></script>


### PR DESCRIPTION
SASS support using
- django_compressor
- django-libsass

files in a block like this will be compiled on the fly

```
{% compress css %}
    <link rel="stylesheet" type="text/x-scss" href="{% static "style.scss" %}" />
{% endcompress %}
```

ready to be merged into `develop`.

needs https://github.com/webuildcity/hamburg/pull/3 to work.
