### PR TITLE
search result order

### DIFF
--- a/wbc/core/templates/core/search.html
+++ b/wbc/core/templates/core/search.html
@@ -121,7 +121,7 @@ SearchController
             <div class="result-list in wbc-dropdown-container">
 
                 <div class="clearfix"
-                    ng-repeat="result in results"
+                    ng-repeat="result in results | orderBy:'name'"
                     ng-mouseover="focusResult(result)"
                     ng-mouseout="defocusResult(result)"
                     ng-click="selectResult(result)">


### PR DESCRIPTION
quick addition I missed to push earlier: default alphanumeric ordering of search results
